### PR TITLE
Correct label of struct map

### DIFF
--- a/specification/specification.md
+++ b/specification/specification.md
@@ -164,7 +164,7 @@ node MUST reference the `/<representation>/METS.xml` and point at the
 corresponding `<file>` entry in the `<fileSec>` using the `<fptr>` element.
 
 ```xml
-<structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP structMap">
+<structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
    <div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
      <div LABEL="representations/images_mig-1">
        <mptr xlink:href="./representations/images_mig-1/METS.xml" xlink:title="Mets file describing representation: images_mig-1 of AIP: urn:uuid:d7ef386d-275b-4a5d-9abf-48de9c390339." LOCTYPE="URL" ID="uuid-c063ebaf-e594-4996-9e2d-37bf91009155"/>


### PR DESCRIPTION
Label of struct map not in line with vocabulary. Issue raised: https://github.com/DILCISBoard/E-ARK-AIP/issues/89